### PR TITLE
Make the extension usable in any language. 

### DIFF
--- a/background.html
+++ b/background.html
@@ -7,12 +7,7 @@ chrome.bookmarks.getTree(function(bookmarks){
     var other_bookmarks, b;
     bookmarks = bookmarks[0];
     if (bookmarks.children) {
-      // Find 'Other Bookmarks' folder
-      for (b in bookmarks.children) {
-        if (bookmarks.children[b].title === 'Other Bookmarks') {
-          other_bookmarks = bookmarks.children[b];
-        }
-      }
+    	other_bookmarks = bookmarks.children[1];
     }
     // Find 'GitHub Favorites' folder
     for (b in other_bookmarks.children) {


### PR DESCRIPTION
Hi,

I´m a programmer from Germany and by this circumstance I couldn't make 'github-favorites' run:
because of the code search in the bookmark tree explicit for the children called "other bookmarks", the extension is not applicable for user with another language. Through these little changes it should be possible to use it in any language. One you can note is that the folder may will be in another order, but at least now it would be possible to rename the folder.
